### PR TITLE
Adds initial implementation for OAuth2 support (#9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 Thumbs.db
 composer.lock
 /coverage
+
+example.php

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,10 @@
     }
   },
   "require": {
-    "guzzlehttp/oauth-subscriber": "~0.3.0",
-    "php": "^7.0"
+    "php": "^7.0",
+    "league/oauth2-client": "^2.4",
+    "guzzlehttp/oauth-subscriber": "^0.3.0",
+    "ext-json": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~6.5.14"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+  <description>xeroclient phpcs configuration</description>
+  <rule ref="PSR2"/>
+</ruleset>

--- a/src/Exception/ResourceOwnerException.php
+++ b/src/Exception/ResourceOwnerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Radcliffe\Xero\Exception;
+
+class ResourceOwnerException extends \Exception
+{
+}

--- a/src/XeroClient.php
+++ b/src/XeroClient.php
@@ -3,18 +3,33 @@
 namespace Radcliffe\Xero;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Subscriber\Oauth\Oauth1;
 use Radcliffe\Xero\Exception\InvalidOptionsException;
 
 class XeroClient extends Client implements XeroClientInterface
 {
+   /**
+    * A list of valid tenant guids.
+    *
+    * @var string[]
+    */
+    protected $tenantIds = [];
+
+    /**
+     * @var
+     */
+    protected $refreshedToken = null;
+
     /**
      * {@inheritdoc}
      */
     public static function getValidUrls()
     {
         return [
+            'https://identity.xero.com/connect/token',
+            'https://api.xero.com/connections',
             'https://api.xero.com/api.xro/2.0/',
             'https://api.xero.com/payroll.xro/1.0/',
             'https://api.xero.com/assets.xro/1.0/',
@@ -27,32 +42,53 @@ class XeroClient extends Client implements XeroClientInterface
      */
     public function __construct(array $config)
     {
+        $options = isset($config['options']) ? $config['options'] : [];
+        $scheme = isset($config['scheme']) ? $config['scheme'] : 'oauth1';
+        $auth = $scheme === 'oauth1' ? 'oauth' : null;
+
         if (!isset($config['base_uri']) ||
             !$config['base_uri'] ||
             !$this->isValidUrl($config['base_uri'])) {
             throw new InvalidOptionsException('API URL is not valid.');
         }
 
-        if (!isset($config['consumer_key']) || !$config['consumer_key']) {
-            throw new InvalidOptionsException('Consumer key not found.');
-        }
+        if ($scheme === 'oauth1') {
+            // Backwards-compatible with oauth1.
+            if (!isset($config['consumer_key']) || !$config['consumer_key']) {
+                throw new InvalidOptionsException('Missing required parameter consumer_key');
+            }
 
-        if (!isset($config['consumer_secret']) || !$config['consumer_secret']) {
-            throw new InvalidOptionsException('Consumer secret not found.');
-        }
+            if (!isset($config['consumer_secret']) || !$config['consumer_secret']) {
+                throw new InvalidOptionsException('Missing required parameter consumer_secret');
+            }
 
-        if ($config['application'] === 'private') {
-            $config['token'] = $config['consumer_key'];
-        }
+            if ($config['application'] === 'private') {
+                $config['token'] = $config['consumer_key'];
+            }
 
-        if ($config['application'] === 'private') {
-            $config['token_secret'] = $config['consumer_secret'];
-        }
+            if ($config['application'] === 'private') {
+                $config['token_secret'] = $config['consumer_secret'];
+            }
 
-        if ($config['application'] === 'private' &&
-            (!isset($config['private_key']) || !$this->isValidPrivateKey($config['private_key']))
-        ) {
-            throw new InvalidOptionsException('Private key not found.');
+            if ($config['application'] === 'private' &&
+                (!isset($config['private_key']) || !$this->isValidPrivateKey($config['private_key']))
+            ) {
+                throw new InvalidOptionsException('Missing required parameter private_key');
+            }
+
+            if ($config['application'] === 'private') {
+                $middleware = $this->getPrivateApplicationMiddleware($config);
+            } else {
+                $middleware = $this->getPublicApplicationMiddleware($config);
+            }
+        } elseif ($scheme === 'oauth2') {
+            // Use OAuth2 work flow.
+            if (!isset($config['auth_token'])) {
+                throw new InvalidOptionsException('Missing required parameter auth_token');
+            }
+            $options['headers']['Authorization'] = 'Bearer ' . $config['auth_token'];
+        } else {
+            throw new InvalidOptionsException('Invalid scheme provided');
         }
 
         if (isset($config['handler']) && is_a($config['handler'], '\GuzzleHttp\HandlerStack')) {
@@ -61,18 +97,14 @@ class XeroClient extends Client implements XeroClientInterface
             $stack = HandlerStack::create();
         }
 
-        if ($config['application'] === 'private') {
-            $middleware = $this->getPrivateApplicationMiddleware($config);
-        } else {
-            $middleware = $this->getPublicApplicationMiddleware($config);
+        if (isset($middleware)) {
+            $stack->push($middleware);
         }
 
-        $stack->push($middleware);
-
-        parent::__construct([
+        parent::__construct($options + [
             'base_uri' => $config['base_uri'],
             'handler' => $stack,
-            'auth' => 'oauth',
+            'auth' => $auth,
         ]);
     }
 
@@ -98,8 +130,11 @@ class XeroClient extends Client implements XeroClientInterface
     /**
      * @param array $options
      *   The options passed into the constructor.
+     *
      * @return \GuzzleHttp\Subscriber\Oauth\Oauth1
      *   OAuth1 middleware.
+     *
+     * @deprecated Deprecated since 0.2.0.
      */
     protected function getPublicApplicationMiddleware($options)
     {
@@ -130,8 +165,11 @@ class XeroClient extends Client implements XeroClientInterface
     /**
      * @param array $options
      *   The options passed into the constructor.
+     *
      * @return \GuzzleHttp\Subscriber\Oauth\Oauth1
      *   OAuth1 middleware.
+     *
+     * @deprecated Deprecated since 0.2.0
      */
     protected function getPrivateApplicationMiddleware($options)
     {
@@ -204,5 +242,72 @@ class XeroClient extends Client implements XeroClientInterface
             $tokens[$parameter] = isset($split[1]) ? urldecode($split[1]) : '';
         }
         return $tokens;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     * @throws \Radcliffe\Xero\Exception\InvalidOptionsException
+     * @throws \GuzzleHttp\Exception\ClientException
+     */
+    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = [])
+    {
+        if ($grant !== null) {
+            // Fetch a new access token from a refresh token.
+            $provider = new XeroProvider([
+                'clientId' => $id,
+                'clientSecret' => $secret,
+                'scopes' => XeroProvider::getValidScopes($api),
+            ]);
+            $token_options = [];
+            if ($grant === 'refresh_token') {
+                $token_options['refresh_token'] = $token;
+            } elseif ($grant === 'authorization_code') {
+                $token_options['code'] = $token;
+            }
+
+            $refreshedToken = $provider->getAccessToken($grant, $token_options);
+            $token = $refreshedToken->getToken();
+        }
+
+        if (!isset($options['base_uri'])) {
+            $options['base_uri'] = 'https://api.xero.com/api.xro/2.0/';
+        }
+
+        // Create a new static instance.
+        $instance = new static($options + [
+            'scheme' => 'oauth2',
+            'auth_token' => $token,
+        ]);
+
+        $response = $instance->get('https://api.xero.com/connections');
+        $instance->tenantIds = json_decode($response->getBody()->getContents(), true);
+
+        if (isset($refreshedToken)) {
+            $instance->refreshedToken = $refreshedToken;
+        }
+
+        return $instance;
+    }
+
+    /**
+     * Access tokens refreshed when creating an instance from a refresh token.
+     *
+     * @return \League\OAuth2\Client\Token\AccessTokenInterface|null
+     */
+    public function getRefreshedToken()
+    {
+        return $this->refreshedToken;
+    }
+
+    /**
+     * The tenant guids accessible by this client.
+     *
+     * @return string[]
+     */
+    public function getTenantIds()
+    {
+        return $this->tenantIds;
     }
 }

--- a/src/XeroClient.php
+++ b/src/XeroClient.php
@@ -251,7 +251,7 @@ class XeroClient extends Client implements XeroClientInterface
      * @throws \Radcliffe\Xero\Exception\InvalidOptionsException
      * @throws \GuzzleHttp\Exception\ClientException
      */
-    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = [])
+    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = [], array $collaborators = [])
     {
         if ($grant !== null) {
             // Fetch a new access token from a refresh token.
@@ -259,7 +259,7 @@ class XeroClient extends Client implements XeroClientInterface
                 'clientId' => $id,
                 'clientSecret' => $secret,
                 'scopes' => XeroProvider::getValidScopes($api),
-            ]);
+            ], $collaborators);
             $token_options = [];
             if ($grant === 'refresh_token') {
                 $token_options['refresh_token'] = $token;

--- a/src/XeroClientInterface.php
+++ b/src/XeroClientInterface.php
@@ -8,7 +8,7 @@ interface XeroClientInterface
     /**
      * Get a list of valid API URLs.
      *
-     * @return array
+     * @return string[]
      */
     public static function getValidUrls();
 
@@ -16,6 +16,7 @@ interface XeroClientInterface
      * Check the URL.
      *
      * @param string $base_uri
+     *
      * @return bool
      *   TRUE if the base uri is valid.
      */
@@ -28,6 +29,8 @@ interface XeroClientInterface
      *   The file name of the private key.
      * @return bool
      *   TRUE if the private key is valid.
+     *
+     * @deprecated Deprecated since 0.2.0
      */
     public function isValidPrivateKey($filename);
 
@@ -35,15 +38,18 @@ interface XeroClientInterface
      * Get an unauthorized request token from the API.
      *
      * @param string $consumer_key
-     *  Consumer key.
+     *   Consumer key.
      * @param string $consumer_secret
-     *  Consumer secret.
+     *   Consumer secret.
      * @param array $options
-     *  An array of request options including other OAuth1 required properties depending on the application type.
+     *   An array of request options including other OAuth1 required properties depending on the application type.
+     *
      * @return array
      *   An associative array consisting of the following keys:
      *   - oauth_token
      *   - oauth_secret
+     *
+     * @deprecated Deprecated since 0.2.0
      */
     public static function getRequestToken($consumer_key, $consumer_secret, $options = []);
 
@@ -51,21 +57,24 @@ interface XeroClientInterface
      * Get an access token from the API.
      *
      * @param string $consumer_key
-     *  Consumer key.
+     *   Consumer key.
      * @param string $consumer_secret
-     *  Consumer secret.
+     *   Consumer secret.
      * @param string $token
-     *  OAuth token.
+     *   OAuth token.
      * @param string $token_secret
-     *  Token secret from the request token.
+     *   Token secret from the request token.
      * @param string $verifier
-     *  The CSRF token provided by the API.
+     *   The CSRF token provided by the API.
      * @param array $options
-     *  An array of request options to provide to Guzzle.
+     *   An array of request options to provide to Guzzle.
+     *
      * @return array
      *   An associative array consisting of the following keys:
      *   - oauth_token
      *   - oauth_secret
+     *
+     * @deprecated Deprecated since 0.2.0
      */
     public static function getAccessToken(
         $consumer_key,
@@ -75,4 +84,41 @@ interface XeroClientInterface
         $verifier,
         $options = []
     );
+
+    /**
+     * Create client from an existing token or code.
+     *
+     * Regardless of the parameters, the returned object will be a Guzzle Client
+     * instance with an Authorization header using the access token for the application.
+     *
+     * There are three ways to do this:
+     *    1. Directly with an existing access token.
+     *    2. Using an authorization code retrieved within 15 minutes to get an access token.
+     *    3. Using a refresh token when an access token has expired after 30 minutes.
+     *
+     * This will create two side-effects:
+     *    1. An additional request will always be made to confirm the tenant ids allowed by
+     *       the access token and stored in $this->tenantIds.
+     *    2. If a code or refresh token is used, then the new access token and related
+     *       information will be stored in $this->refreshedToken.
+     *
+     * @param string $id
+     *   The Oauth2 client id.
+     * @param string $secret
+     *   The Oauth2 client secret.
+     * @param string $token
+     *   An access token, refresh token, or authorization code.
+     * @param string $grant
+     *   An optional grant type when refreshing or getting a new access token.
+     *     - refresh_token: the provided token is a refresh token.
+     *     - authorization_code: the provided token is an authorization code.
+     * @param string $api
+     *   The Xero API to scope to which is one of the following: accounting,
+     *   payroll_COUNTRYCODE, files, assets, projects, restricted, or openid.
+     * @param array $options
+     *   Any additional options to pass to the constructor.
+     *
+     * @return static
+     */
+    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = []);
 }

--- a/src/XeroClientInterface.php
+++ b/src/XeroClientInterface.php
@@ -117,8 +117,12 @@ interface XeroClientInterface
      *   payroll_COUNTRYCODE, files, assets, projects, restricted, or openid.
      * @param array $options
      *   Any additional options to pass to the constructor.
+     * @param array $collaborators
+     *   Collaborator options to pass-through to the provider initialize method.
+     *
+     * @see \League\OAuth2\Client\Provider\AbstractProvider::__construct()
      *
      * @return static
      */
-    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = []);
+    public static function createFromToken($id, $secret, $token, $grant = null, $api = 'accounting', array $options = [], array $collaborators = []);
 }

--- a/src/XeroProvider.php
+++ b/src/XeroProvider.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Radcliffe\Xero;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
+use League\OAuth2\Client\Token\AccessToken;
+use Psr\Http\Message\ResponseInterface;
+use Radcliffe\Xero\Exception\ResourceOwnerException;
+
+/**
+ * Implements an OAuth2 provider.
+ */
+class XeroProvider extends AbstractProvider
+{
+    protected $errorMap = [
+        'invalid_client' => 'Invalid client credentials',
+        'unsupported_grant_type' => 'Missing required grant_type parameter',
+        'invalid_grant' => 'Invalid, expired, or already used code',
+        'unauthorized_client' => 'Invalid callback URI',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseAuthorizationUrl()
+    {
+        return 'https://login.xero.com/identity/connect/authorize';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBaseAccessTokenUrl(array $params)
+    {
+        return 'https://identity.xero.com/connect/token';
+    }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Radcliffe\Xero\Exception\ResourceOwnerException
+   */
+    public function getResourceOwnerDetailsUrl(AccessToken $token)
+    {
+        throw new ResourceOwnerException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getDefaultScopes()
+    {
+        return ['offline_access'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function checkResponse(ResponseInterface $response, $data)
+    {
+        $statusCode = $response->getStatusCode();
+        if ($statusCode === 429) {
+            throw new IdentityProviderException('Rate limit exceeded', $statusCode, '');
+        } elseif ($statusCode >= 400) {
+            $rawText = $response->getBody()->getContents();
+            throw new IdentityProviderException($this->getResponseMessage($rawText), $statusCode, $rawText);
+        }
+    }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @throws \Radcliffe\Xero\Exception\ResourceOwnerException
+   */
+    protected function createResourceOwner(array $response, AccessToken $token)
+    {
+        throw new ResourceOwnerException();
+    }
+
+    /**
+     * Gets a formatted error message from an error response.
+     *
+     * @param string $raw
+     *   The raw response body.
+     *
+     * @return string
+     */
+    protected function getResponseMessage($raw)
+    {
+        // Attempts to decode the response body as simple JSON.
+
+        $data = json_decode($raw, true);
+        $error = 'An unknown error occurred with this request';
+        if ($data !== null && isset($data['error'])) {
+            if (isset($this->errorMap[$data['error']])) {
+                $error = $data['error'];
+            } else {
+                $error = 'Unknown error code ' . $data['error'];
+            }
+        }
+
+        return $error;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+    /**
+     * Gets the valid scopes for an API.
+     *
+     * @param string $api
+     *   (optional) One of openid, accounting, payroll_COUNTRYID, files, assets, projects, or restricted.
+     *
+     * @return string[]
+     */
+    public static function getValidScopes($api = '')
+    {
+        $scopes = ['offline_access'];
+        if ($api === 'openid') {
+            $scopes = array_merge($scopes, ['openid', 'profile', 'email']);
+        } elseif ($api === 'accounting') {
+            $types = ['transactions', 'settings', 'contacts', 'attachments'];
+            foreach ($types as $type) {
+                $scopes[] = "accounting.$type";
+                $scopes[] = "accounting.$type.read";
+            }
+            $scopes = array_merge($scopes, ['accounting.reports.read', 'accounting.journal.read']);
+        } elseif (substr($api, 0, 7) === 'payroll') {
+            // @todo Split the logic into au, uk, nz, and other sections as necessary.
+            $types = ['employees', 'payruns', 'payslip', 'timesheets', 'settings'];
+            foreach ($types as $type) {
+                $scopes[] = "payroll.$type";
+                $scopes[] = "payroll.$type.read";
+            }
+        } elseif ($api === 'files') {
+            $scopes = array_merge($scopes, ['files', 'files.read']);
+        } elseif ($api === 'assets') {
+            $scopes = array_merge($scopes, ['assets', 'assets.read']);
+        } elseif ($api === 'projects') {
+            $scopes = array_merge($scopes, ['projects', 'projects.read']);
+        } elseif ($api === 'restricted') {
+            $scopes = array_merge($scopes, ['paymentservices', 'bankfeeds']);
+        }
+
+        return $scopes;
+    }
+}

--- a/src/XeroProvider.php
+++ b/src/XeroProvider.php
@@ -61,10 +61,9 @@ class XeroProvider extends AbstractProvider
     {
         $statusCode = $response->getStatusCode();
         if ($statusCode === 429) {
-            throw new IdentityProviderException('Rate limit exceeded', $statusCode, '');
+            throw new IdentityProviderException('Rate limit exceeded', $statusCode, $data);
         } elseif ($statusCode >= 400) {
-            $rawText = $response->getBody()->getContents();
-            throw new IdentityProviderException($this->getResponseMessage($rawText), $statusCode, $rawText);
+            throw new IdentityProviderException($this->getResponseMessage($data), $statusCode, $data);
         }
     }
 
@@ -81,16 +80,13 @@ class XeroProvider extends AbstractProvider
     /**
      * Gets a formatted error message from an error response.
      *
-     * @param string $raw
-     *   The raw response body.
+     * @param array $data
+     *   The structured response message.
      *
      * @return string
      */
-    protected function getResponseMessage($raw)
+    protected function getResponseMessage($data)
     {
-        // Attempts to decode the response body as simple JSON.
-
-        $data = json_decode($raw, true);
         $error = 'An unknown error occurred with this request';
         if ($data !== null && isset($data['error'])) {
             if (isset($this->errorMap[$data['error']])) {

--- a/tests/src/XeroClientOAuth2Test.php
+++ b/tests/src/XeroClientOAuth2Test.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Radcliffe\Tests\Xero;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Prophecy\Argument;
+use Radcliffe\Xero\XeroClient;
+
+/**
+ * Tests XeroClient OAuth2 code.
+ *
+ * @group xeroclient
+ */
+class XeroClientOAuth2Test extends XeroClientTestBase
+{
+    protected $clientId;
+    protected $clientSecret;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->clientId = $this->createRandomString();
+        $this->clientSecret = $this->createRandomString();
+    }
+
+    /**
+     * Tests that an exception is thrown for Xero API 403 status code.
+     *
+     * @expectedException \League\Oauth2\CLient\Provider\Exception\IdentityProviderException
+     */
+    public function testCreateFromTokenError()
+    {
+        $mock = new MockHandler([
+            new Response(403, ['Content-Type' => 'application/json'], json_encode([
+                'title' => 'Forbidden',
+                'status' => 403,
+                'detail' => 'AuthenticationUnsuccessful',
+                'instance' => $this->createGuid(),
+            ])),
+        ]);
+        $options = ['handler' => new HandlerStack($mock)];
+        $httpClient = new Client($options);
+
+        XeroClient::createFromToken(
+            $this->clientId,
+            $this->clientSecret,
+            $this->createRandomString(),
+            'refresh_token',
+            'accounting',
+            $options,
+            ['httpClient' => $httpClient]
+        );
+    }
+
+    /**
+     * Tests creating from a refresh token.
+     *
+     * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     * @throws \Radcliffe\Xero\Exception\InvalidOptionsException
+     */
+    public function testCreateFromRefreshToken()
+    {
+        $token = $this->createRandomString(30);
+        $refresh_token = $this->createRandomString(30);
+        $tenantIdResponse = json_encode([
+            [
+                'id' => $this->createGuid(),
+                'tenantId' => $this->createGuid(),
+                'tenantType' => 'ORGANISATION',
+            ],
+        ]);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], $tenantIdResponse),
+        ]);
+        $options = ['handler' => new HandlerStack($mock)];
+
+        // Mocks the OAuth2 Client request factory and requests.
+        $refreshTokenResponse = json_encode([
+            'access_token' => $token,
+            'refresh_token' => $refresh_token,
+            'expires' => time() + 1800,
+            'token_type' => 'Bearer',
+        ]);
+        $providerMock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], $refreshTokenResponse),
+        ]);
+        $providerOptions = ['handler' => new HandlerStack($providerMock)];
+
+        $httpClient = new Client($providerOptions);
+
+        $client = XeroClient::createFromToken(
+            $this->clientId,
+            $this->clientSecret,
+            $token,
+            'refresh_token',
+            'accounting',
+            $options,
+            ['httpClient' => $httpClient]
+        );
+
+        $this->assertInstanceOf('\Radcliffe\Xero\XeroClient', $client);
+    }
+
+    /**
+     * Tests creating from an access token.
+     *
+     * @throws \League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     * @throws \Radcliffe\Xero\Exception\InvalidOptionsException
+     */
+    public function testCreateFromAccessToken()
+    {
+        $token = $this->createRandomString(30);
+        $tenantIdResponse = json_encode([
+            [
+                'id' => $this->createGuid(),
+                'tenantId' => $this->createGuid(),
+                'tenantType' => 'ORGANISATION',
+            ],
+        ]);
+        $mock = new MockHandler([
+            new Response(200, ['Content-Type' => 'application/json'], $tenantIdResponse),
+        ]);
+        $options = ['handler' => new HandlerStack($mock)];
+
+        $client = XeroClient::createFromToken(
+            $this->clientId,
+            $this->clientSecret,
+            $token,
+            null,
+            'accounting',
+            $options
+        );
+
+        $this->assertInstanceOf('\Radcliffe\Xero\XeroClient', $client);
+    }
+}

--- a/tests/src/XeroProviderTest.php
+++ b/tests/src/XeroProviderTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Radcliffe\Tests\Xero;
+
+use Radcliffe\Xero\XeroProvider;
+use PHPUnit\Framework\TestCase;
+
+class XeroProviderTest extends TestCase
+{
+    /**
+     * Asserts that the valid scopes are returned based on the api.
+     *
+     * @param array $expected
+     *   The expected result.
+     * @param string $api
+     *   The api parameter.
+     *
+     * @dataProvider validScopesProvider
+     */
+    public function testGetValidScopes(array $expected, $api = '')
+    {
+        $this->assertEquals($expected, XeroProvider::getValidScopes($api));
+    }
+
+    public function validScopesProvider()
+    {
+        return [
+            [['offline_access'], null],
+            [['offline_access', 'openid', 'profile', 'email'], 'openid'],
+            [
+              [
+                  'offline_access',
+                  'accounting.transactions',
+                  'accounting.transactions.read',
+                  'accounting.settings',
+                  'accounting.settings.read',
+                  'accounting.contacts',
+                  'accounting.contacts.read',
+                  'accounting.attachments',
+                  'accounting.attachments.read',
+                  'accounting.reports.read',
+                  'accounting.journal.read',
+              ],
+              'accounting',
+            ],
+            [
+                [
+                    'offline_access',
+                    'payroll.employees',
+                    'payroll.employees.read',
+                    'payroll.payruns',
+                    'payroll.payruns.read',
+                    'payroll.payslip',
+                    'payroll.payslip.read',
+                    'payroll.timesheets',
+                    'payroll.timesheets.read',
+                    'payroll.settings',
+                    'payroll.settings.read',
+                ],
+                'payroll_uk',
+            ],
+            [
+              [
+                'offline_access',
+                'payroll.employees',
+                'payroll.employees.read',
+                'payroll.payruns',
+                'payroll.payruns.read',
+                'payroll.payslip',
+                'payroll.payslip.read',
+                'payroll.timesheets',
+                'payroll.timesheets.read',
+                'payroll.settings',
+                'payroll.settings.read',
+              ],
+              'payroll_nz',
+            ],
+            [
+                ['offline_access', 'files', 'files.read'],
+                'files',
+            ],
+            [
+                ['offline_access', 'projects', 'projects.read'],
+                'projects',
+            ],
+            [
+                ['offline_access', 'paymentservices', 'bankfeeds'],
+                'restricted',
+            ],
+        ];
+    }
+}

--- a/tests/src/XeroProviderTest.php
+++ b/tests/src/XeroProviderTest.php
@@ -75,18 +75,10 @@ class XeroProviderTest extends TestCase
               ],
               'payroll_nz',
             ],
-            [
-                ['offline_access', 'files', 'files.read'],
-                'files',
-            ],
-            [
-                ['offline_access', 'projects', 'projects.read'],
-                'projects',
-            ],
-            [
-                ['offline_access', 'paymentservices', 'bankfeeds'],
-                'restricted',
-            ],
+            [['offline_access', 'files', 'files.read'], 'files'],
+            [['offline_access', 'projects', 'projects.read'], 'projects'],
+            [['offline_access', 'paymentservices', 'bankfeeds'], 'restricted'],
+            [['offline_access', 'assets', 'assets.read'], 'assets'],
         ];
     }
 }


### PR DESCRIPTION
Resolves issue #9 

### Summary of Changes

* *Adds* a league/oauth2-client provider, XeroProvider
* *Changes* the behavior of XeroClient constructor to support oauth1 and oauth2 based on new optional "scheme"
* *Adds* a static method to create a xero client based on authorization code, access token, or refresh token scenarios.
* *Deprecates* all oauth1 related functionality.
* *Change* documentation to reference OAuth2 methodology.

### Remaining Tasks

- [x] Needs unit test coverage for XeroClient when using oauth2 scheme.

### Attribution

* @mradcliffe
*
*
*
